### PR TITLE
Change to make startLastSeq,endLastSeq,recordedSeq as type String,

### DIFF
--- a/src/main/java/org/lightcouch/ReplicationResult.java
+++ b/src/main/java/org/lightcouch/ReplicationResult.java
@@ -16,9 +16,9 @@
 
 package org.lightcouch;
 
-import java.util.List;
-
 import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
 
 /**
  * Holds the result of a replication request, along with previous sessions history.
@@ -79,11 +79,11 @@ public class ReplicationResult {
 		@SerializedName("end_time")
 		private String endTime;
 		@SerializedName("start_last_seq")
-		private long startLastSeq;
+		private String startLastSeq;
 		@SerializedName("end_last_seq")
-		private long endLastSeq;
+		private String endLastSeq;
 		@SerializedName("recorded_seq")
-		private long recordedSeq;
+		private String recordedSeq;
 		@SerializedName("missing_checked")
 		private long missingChecked;
 		@SerializedName("missing_found")
@@ -107,15 +107,15 @@ public class ReplicationResult {
 			return endTime;
 		}
 
-		public long getStartLastSeq() {
+		public String getStartLastSeq() {
 			return startLastSeq;
 		}
 
-		public long getEndLastSeq() {
+		public String getEndLastSeq() {
 			return endLastSeq;
 		}
 
-		public long getRecordedSeq() {
+		public String getRecordedSeq() {
 			return recordedSeq;
 		}
 
@@ -151,15 +151,15 @@ public class ReplicationResult {
 			this.endTime = endTime;
 		}
 
-		public void setStartLastSeq(long startLastSeq) {
+		public void setStartLastSeq(String startLastSeq) {
 			this.startLastSeq = startLastSeq;
 		}
 
-		public void setEndLastSeq(long endLastSeq) {
+		public void setEndLastSeq(String endLastSeq) {
 			this.endLastSeq = endLastSeq;
 		}
 
-		public void setRecordedSeq(long recordedSeq) {
+		public void setRecordedSeq(String recordedSeq) {
 			this.recordedSeq = recordedSeq;
 		}
 

--- a/src/test/java/org/lightcouch/tests/ReplicationResultTest.java
+++ b/src/test/java/org/lightcouch/tests/ReplicationResultTest.java
@@ -1,0 +1,33 @@
+package org.lightcouch.tests;
+
+import com.google.gson.Gson;
+import org.junit.Test;
+import org.lightcouch.ReplicationResult;
+
+import static org.junit.Assert.assertEquals;
+
+public class ReplicationResultTest {
+
+    @Test
+    public void testWithCloudantResult() throws Exception {
+        ReplicationResult replicationResult=new Gson().fromJson("{\"ok\":true,\n" +
+                "\"session_id\":\"b062b02fccd6dbdf1a818b29a7dbe185\",\n" +
+                "\"source_last_seq\":\"9-g1AAAADdeJzLYWBgYMlgTmGQS0lKzi9KdUhJMjTWyyrNSS3QS87JL01JzCvRy0styQGqY0pkSLL___9_ViIzSIcsXIclLg1JDkAyqR6sh4lYW_JYgCRDA5AC6tsP1UiEZRB9ByD6QBZmAQD8g0jz\",\n" +
+                "\"history\":[{\"session_id\":\"b062b02fccd6dbdf1a818b29a7dbe185\",\n" +
+                "            \"start_time\":\"Sat, 14 Apr 2012 11:49:00 GMT\",\n" +
+                "            \"end_time\":\"Sat, 14 Apr 2012 11:49:01 GMT\",\n" +
+                "            \"start_last_seq\":0,\n" +
+                "            \"end_last_seq\":\"9-g1AAAADdeJzLYWBgYMlgTmGQS0lKzi9KdUhJMjTWyyrNSS3QS87JL01JzCvRy0styQGqY0pkSLL___9_ViIzSIcsXIclLg1JDkAyqR6sh4lYW_JYgCRDA5AC6tsP1UiEZRB9ByD6QBZmAQD8g0jz\",\n" +
+                "            \"recorded_seq\":\"9-g1AAAADdeJzLYWBgYMlgTmGQS0lKzi9KdUhJMjTWyyrNSS3QS87JL01JzCvRy0styQGqY0pkSLL___9_ViIzSIcsXIclLg1JDkAyqR6sh4lYW_JYgCRDA5AC6tsP1UiEZRB9ByD6QBZmAQD8g0jz\",\n" +
+                "            \"missing_checked\":0,\n" +
+                "            \"missing_found\":34,\n" +
+                "            \"docs_read\":34,\n" +
+                "            \"docs_written\":34,\n" +
+                "            \"doc_write_failures\":0}]}\n" +
+                "", ReplicationResult.class);
+
+        final ReplicationResult.ReplicationHistory firstHistory = replicationResult.getHistories().get(0);
+        assertEquals("9-g1AAAADdeJzLYWBgYMlgTmGQS0lKzi9KdUhJMjTWyyrNSS3QS87JL01JzCvRy0styQGqY0pkSLL___9_ViIzSIcsXIclLg1JDkAyqR6sh4lYW_JYgCRDA5AC6tsP1UiEZRB9ByD6QBZmAQD8g0jz", firstHistory.getEndLastSeq());
+        assertEquals("9-g1AAAADdeJzLYWBgYMlgTmGQS0lKzi9KdUhJMjTWyyrNSS3QS87JL01JzCvRy0styQGqY0pkSLL___9_ViIzSIcsXIclLg1JDkAyqR6sh4lYW_JYgCRDA5AC6tsP1UiEZRB9ByD6QBZmAQD8g0jz", firstHistory.getRecordedSeq());
+    }
+}


### PR DESCRIPTION
because Cloudant database returns them as Strings in the replication history

fixes : https://github.com/ahmedyha/LightCouch/issues/9
