### PR TITLE
Changed request log to decode URI encoded request path (UTF-8 support)

### DIFF
--- a/src/main/java/org/lightcouch/CouchDbClientBase.java
+++ b/src/main/java/org/lightcouch/CouchDbClientBase.java
@@ -40,6 +40,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
+import org.apache.http.RequestLine;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
@@ -94,13 +95,13 @@ import com.google.gson.reflect.TypeToken;
 abstract class CouchDbClientBase {
 
 	static final Log log = LogFactory.getLog(CouchDbClientBase.class);
-	
+
 	private HttpClient httpClient;
 	private URI baseURI;
 	private URI dbURI;
 	private Gson gson; 
 	private CouchDbConfig config;
-	
+
 	private HttpHost host;
 	private AuthCache authCache;
 	
@@ -344,8 +345,10 @@ abstract class CouchDbClientBase {
                 public void process(
                         final HttpRequest request,
                         final HttpContext context) throws IOException {
-                	if(log.isInfoEnabled()) 
-        				log.info(">> " + request.getRequestLine());
+                    if (log.isInfoEnabled()) {
+                        RequestLine requestLine = request.getRequestLine();
+                        log.info(">> " + requestLine.getMethod() + " " + URI.create(requestLine.getUri()).getPath());
+                    }
                 }
             });
 			// response interceptor


### PR DESCRIPTION
While trying to debug a request that contains UTF-8 characters I was unable to understand what was the request path as it was URL encoded.
For example: 

```
>> GET /luz4u/LectureType:%D7%A1%D7%9E%D7%A0%D7%A8%D7%99%D7%95%D7%9F%20%D7%95%D7%A9%D7%99%D7%A2%D7%95%D7%A8 HTTP/1.1
```

This commit would make it appear as:

```
>> GET /luz4u/LectureType:סמנריון ושיעור
```

I have removed the protocol version on the way. Can be added.
