### PR TITLE
Update the dependency on HttpClient to 4.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 	</developers>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<httpclient.version>4.2.5</httpclient.version>
+		<httpclient.version>4.3.2</httpclient.version>
 		<gson.version>2.2.4</gson.version>
 		<junit.version>4.8.2</junit.version>
 	</properties>

--- a/src/main/java/org/lightcouch/CouchDbClientBase.java
+++ b/src/main/java/org/lightcouch/CouchDbClientBase.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.security.cert.CertificateException;
@@ -414,18 +413,13 @@ abstract class CouchDbClientBase {
 	 * @param httpRequest The request to set entity.
 	 * @param json The JSON String to set.
 	 */
-	protected void setEntity(HttpEntityEnclosingRequestBase httpRequest, String json) {
-		try {
-			StringEntity entity = new StringEntity(json, "UTF-8");
-			entity.setContentType("application/json");
-			httpRequest.setEntity(entity);
-		} catch (UnsupportedEncodingException e) {
-			log.error("Error setting request data. " + e.getMessage());
-			throw new IllegalArgumentException(e);
-		}
-	}
-	
-	/**
+    protected void setEntity(HttpEntityEnclosingRequestBase httpRequest, String json) {
+        StringEntity entity = new StringEntity(json, "UTF-8");
+        entity.setContentType("application/json");
+        httpRequest.setEntity(entity);
+    }
+
+    /**
 	 * @return {@link InputStream} from a {@link HttpResponse}
 	 */
 	InputStream getStream(HttpResponse response) {


### PR DESCRIPTION
Hi,

LightCounch doesn't compile with a more recent version of HttpClient due to a minor incompatibility, here is a patch fixing it.
