### PR TITLE
Added space between method and URL

### DIFF
--- a/src/main/java/org/lightcouch/CouchDbClient.java
+++ b/src/main/java/org/lightcouch/CouchDbClient.java
@@ -208,7 +208,7 @@ public class CouchDbClient extends CouchDbClientBase {
 					final HttpContext context) throws IOException {
 				if (log.isInfoEnabled()) {
 					RequestLine req = request.getRequestLine();
-					log.info("> " + req.getMethod() + URLDecoder.decode(req.getUri(), "UTF-8"));
+					log.info("> " + req.getMethod() + " " + URLDecoder.decode(req.getUri(), "UTF-8"));
 				}
 			}
 		});


### PR DESCRIPTION
Currently logs read like so:

GET/db/doc_id

This change makes logs appear like so:

GET /db/doc_id
