### PR TITLE
Both type of keys and type of values must not be provided when the DB is...

### DIFF
--- a/src/main/java/org/lightcouch/View.java
+++ b/src/main/java/org/lightcouch/View.java
@@ -186,9 +186,6 @@ public class View {
 			vr.setOffset(getAsInt(json, "offset"));
 			vr.setUpdateSeq(getAsLong(json, "update_seq"));
 			JsonArray jsonArray = json.getAsJsonArray("rows");
-			if(jsonArray.size() == 0) { // validate available rows
-				throw new NoDocumentException("No result was returned by this view query.");
-			}
 			for (JsonElement e : jsonArray) {
 				ViewResult<K, V, T>.Rows row = vr.new Rows();
 				row.setId(JsonToObject(gson, e, "id", String.class));

--- a/src/main/java/org/lightcouch/View.java
+++ b/src/main/java/org/lightcouch/View.java
@@ -192,8 +192,12 @@ public class View {
 			for (JsonElement e : jsonArray) {
 				ViewResult<K, V, T>.Rows row = vr.new Rows();
 				row.setId(JsonToObject(gson, e, "id", String.class));
-				row.setKey(JsonToObject(gson, e, "key", classOfK));
-				row.setValue(JsonToObject(gson, e, "value", classOfV));
+				if (classOfK != null) {
+				    row.setKey(JsonToObject(gson, e, "key", classOfK));
+				}
+				if (classOfV != null) {
+				    row.setValue(JsonToObject(gson, e, "value", classOfV));
+				}
 				if(Boolean.TRUE.equals(this.includeDocs)) {
 					row.setDoc(JsonToObject(gson, e, "doc", classOfT));
 				}

--- a/src/test/java/org/lightcouch/tests/ViewsTest.java
+++ b/src/test/java/org/lightcouch/tests/ViewsTest.java
@@ -100,6 +100,18 @@ public class ViewsTest {
 				.reduce(false)
 				.queryView(int[].class, String.class, Foo.class);
 		assertThat(viewResult.getRows().size(), is(3));
+
+		// not interested in keys
+		viewResult = dbClient.view("example/by_date")
+				.reduce(false)
+				.queryView(null, String.class, Foo.class);
+		assertThat(viewResult.getRows().size(), is(3));
+
+		// not interested in values
+		viewResult = dbClient.view("example/by_date")
+				.reduce(false)
+				.queryView(int[].class, null, Foo.class);
+		assertThat(viewResult.getRows().size(), is(3));
 	}
 
 	@Test


### PR DESCRIPTION
... queried.

This is useful if the client is rather generic and does
want to decide later what type of data is needed, e.g. ID and value of rows but not the key.
