### PR TITLE
Bug: Document fetching using views resulted in wrong character encoding (e.g. for Umlauts)

### DIFF
--- a/src/main/java/org/lightcouch/Changes.java
+++ b/src/main/java/org/lightcouch/Changes.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 
+import org.apache.commons.codec.Charsets;
 import org.apache.http.client.methods.HttpGet;
 import org.lightcouch.ChangesResult.Row;
 
@@ -85,7 +86,7 @@ public class Changes {
 		final URI uri = uriBuilder.query("feed", "continuous").build();
 		httpGet = new HttpGet(uri);
 		final InputStream in = dbc.get(httpGet);
-		final InputStreamReader is = new InputStreamReader(in);
+		final InputStreamReader is = new InputStreamReader(in, Charsets.UTF_8);
 		setReader(new BufferedReader(is));
 		return this;
 	}

--- a/src/main/java/org/lightcouch/CouchDbClientBase.java
+++ b/src/main/java/org/lightcouch/CouchDbClientBase.java
@@ -34,6 +34,7 @@ import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.List;
 
+import org.apache.commons.codec.Charsets;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpHost;
@@ -654,7 +655,7 @@ public abstract class CouchDbClientBase {
 	 * @return {@link Response}
 	 */
 	private Response getResponse(HttpResponse response) throws CouchDbException {
-		InputStreamReader reader = new InputStreamReader(getStream(response));
+		InputStreamReader reader = new InputStreamReader(getStream(response), Charsets.UTF_8);
 		return getGson().fromJson(reader, Response.class);
 	}
 	
@@ -664,7 +665,7 @@ public abstract class CouchDbClientBase {
 	 */
 	private List<Response> getResponseList(HttpResponse response) throws CouchDbException {
 		InputStream instream = getStream(response);
-		Reader reader = new InputStreamReader(instream);
+		Reader reader = new InputStreamReader(instream, Charsets.UTF_8);
 		return getGson().fromJson(reader, new TypeToken<List<Response>>(){}.getType());
 	}
 	

--- a/src/main/java/org/lightcouch/CouchDbContext.java
+++ b/src/main/java/org/lightcouch/CouchDbContext.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.List;
 
+import org.apache.commons.codec.Charsets;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
@@ -98,7 +99,7 @@ public class CouchDbContext {
 		try {
 			Type typeOfList = new TypeToken<List<String>>() {}.getType();
 			instream = dbc.get(buildUri(dbc.getBaseUri()).path("_all_dbs").build());
-			Reader reader = new InputStreamReader(instream);
+			Reader reader = new InputStreamReader(instream, Charsets.UTF_8);
 			return dbc.getGson().fromJson(reader, typeOfList);
 		} finally {
 			close(instream);
@@ -119,7 +120,7 @@ public class CouchDbContext {
 		InputStream instream = null;
 		try {
 			instream = dbc.get(buildUri(dbc.getBaseUri()).build());
-			Reader reader = new InputStreamReader(instream);
+			Reader reader = new InputStreamReader(instream, Charsets.UTF_8);
 			return getAsString(new JsonParser().parse(reader).getAsJsonObject(), "version");
 		} finally {
 			close(instream);

--- a/src/main/java/org/lightcouch/Replication.java
+++ b/src/main/java/org/lightcouch/Replication.java
@@ -25,6 +25,7 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.util.Map;
 
+import org.apache.commons.codec.Charsets;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
@@ -100,7 +101,7 @@ public class Replication {
 			}
 			final URI uri = buildUri(dbc.getBaseUri()).path("_replicate").build();
 			response = dbc.post(uri, json.toString());
-			final InputStreamReader reader = new InputStreamReader(getStream(response));
+			final InputStreamReader reader = new InputStreamReader(getStream(response), Charsets.UTF_8);
 			return dbc.getGson().fromJson(reader, ReplicationResult.class);
 		} finally {
 			close(response);

--- a/src/main/java/org/lightcouch/Replicator.java
+++ b/src/main/java/org/lightcouch/Replicator.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.codec.Charsets;
 import org.lightcouch.ReplicatorDocument.UserCtx;
 
 import com.google.gson.JsonArray;
@@ -123,7 +124,7 @@ public class Replicator {
 		InputStream instream = null;
 		try {  
 			final URI uri = buildUri(dbURI).path("_all_docs").query("include_docs", "true").build();
-			final Reader reader = new InputStreamReader(instream = dbc.get(uri));
+			final Reader reader = new InputStreamReader(instream = dbc.get(uri), Charsets.UTF_8);
 			final JsonArray jsonArray = new JsonParser().parse(reader)
 					.getAsJsonObject().getAsJsonArray("rows");
 			final List<ReplicatorDocument> list = new ArrayList<ReplicatorDocument>();

--- a/src/main/java/org/lightcouch/View.java
+++ b/src/main/java/org/lightcouch/View.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.commons.codec.Charsets;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -149,7 +150,7 @@ public class View {
 	public <T> List<T> query(Class<T> classOfT) {
 		InputStream instream = null;
 		try {  
-			Reader reader = new InputStreamReader(instream = queryForStream());
+			Reader reader = new InputStreamReader(instream = queryForStream(), Charsets.UTF_8);
 			JsonArray jsonArray = new JsonParser().parse(reader)
 					.getAsJsonObject().getAsJsonArray("rows");
 			List<T> list = new ArrayList<T>();
@@ -179,7 +180,7 @@ public class View {
 	public <K, V, T> ViewResult<K, V, T> queryView(Class<K> classOfK, Class<V> classOfV, Class<T> classOfT) {
 		InputStream instream = null;
 		try {  
-			Reader reader = new InputStreamReader(instream = queryForStream());
+			Reader reader = new InputStreamReader(instream = queryForStream(), Charsets.UTF_8);
 			JsonObject json = new JsonParser().parse(reader).getAsJsonObject(); 
 			ViewResult<K, V, T> vr = new ViewResult<K, V, T>();
 			vr.setTotalRows(getAsLong(json, "total_rows")); 
@@ -239,7 +240,7 @@ public class View {
 	private <V> V queryValue(Class<V> classOfV) {
 		InputStream instream = null;
 		try {  
-			Reader reader = new InputStreamReader(instream = queryForStream());
+			Reader reader = new InputStreamReader(instream = queryForStream(), Charsets.UTF_8);
 			JsonArray array = new JsonParser().parse(reader).
 							getAsJsonObject().get("rows").getAsJsonArray();
 			if(array.size() != 1) { // expect exactly 1 row


### PR DESCRIPTION
Hey guys,

thanks for your great tool, it is really fun to use! I recently stumbled across an encoding issue: fetching documents via views does not encode them in UTF-8. I tried to fix that and also changed all other InputStreamReaders so that it now should consistently be UTF-8 everywhere.

I hope you approve of this change and add it to the trunk.

Cheers,
Sebastian