### PR TITLE
Access Jar file through web service

### DIFF
--- a/src/main/java/org/lightcouch/CouchDbUtil.java
+++ b/src/main/java/org/lightcouch/CouchDbUtil.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.net.JarURLConnection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -117,8 +118,8 @@ final class CouchDbUtil {
 				return Arrays.asList(new File(dirURL.toURI()).list());
 			}
 			if (dirURL != null && dirURL.getProtocol().equals("jar")) {
-				String jarPath = dirURL.getPath().substring(5, dirURL.getPath().indexOf("!")); 
-				JarFile jar = new JarFile(URLDecoder.decode(jarPath, "UTF-8"));
+				JarURLConnection jarConn = (JarURLConnection)dirURL.openConnection();
+				JarFile jar = jarConn.getJarFile();
 				Enumeration<JarEntry> entries = jar.entries(); 
 				Set<String> result = new HashSet<String>(); 
 				while(entries.hasMoreElements()) {
@@ -134,7 +135,7 @@ final class CouchDbUtil {
 						}
 					}
 				}
-				close(jar);
+				jar.close();
 				return new ArrayList<String>(result);
 			} 
 			return null;


### PR DESCRIPTION
I have a Java applet within a selfdeploying jar file which is accessible through a web service (e.g. http://localhost:80/lulu).
The original implementation tooks the URL as a local network path which failed to find the jar. JarURLConnection handles the given URL correct and provides also a JarFile instance.