### PR TITLE
Allow pagination to work on _all_docs

### DIFF
--- a/guide/src/docbkx/lightcouch-guide.xml
+++ b/guide/src/docbkx/lightcouch-guide.xml
@@ -605,7 +605,7 @@ int resultsPerPage = 15;
 // null param gets the first page
 Page<Foo> page = dbClient.view("example/foo")
   .reduce(false)
-  .queryPage(resultsPerPage, param, Foo.class); 
+  .queryPage(resultsPerPage, param, String.class, Foo.class);
 
 request.setAttribute("page", page);
 

--- a/src/main/java/org/lightcouch/View.java
+++ b/src/main/java/org/lightcouch/View.java
@@ -259,12 +259,13 @@ public class View {
 	 * @param <T> Object type T
 	 * @param rowsPerPage The number of rows per page.
 	 * @param param The request parameter to use to query a page, or {@code null} to return the first page.
+	 * @param classOfV The class of type V
 	 * @param classOfT The class of type T.
 	 * @return {@link Page}
 	 */
-	public <T> Page<T> queryPage(int rowsPerPage, String param, Class<T> classOfT) {
+	public <V,T> Page<T> queryPage(int rowsPerPage, String param, Class<V> classOfV, Class<T> classOfT) {
 		if(param == null) { // assume first page
-			return queryNextPage(rowsPerPage, null, null, null, null, classOfT);
+			return queryNextPage(rowsPerPage, null, null, null, null, classOfV, classOfT);
 		}
 		String currentStartKey;
 		String currentStartKeyDocId;
@@ -287,17 +288,17 @@ public class View {
 			throw new CouchDbException("could not parse the given param!", e);
 		}
 		if(PREVIOUS.equals(action)) { // previous
-			return queryPreviousPage(rowsPerPage, currentStartKey, currentStartKeyDocId, startKey, startKeyDocId, classOfT);
+			return queryPreviousPage(rowsPerPage, currentStartKey, currentStartKeyDocId, startKey, startKeyDocId, classOfV, classOfT);
 		} else { // next
-			return queryNextPage(rowsPerPage, currentStartKey, currentStartKeyDocId, startKey, startKeyDocId, classOfT);
+			return queryNextPage(rowsPerPage, currentStartKey, currentStartKeyDocId, startKey, startKeyDocId, classOfV, classOfT);
 		}
 	}
 	
 	/**
 	 * @return The next page.
 	 */
-	private <T> Page<T> queryNextPage(int rowsPerPage, String currentStartKey, 
-			String currentStartKeyDocId, String startKey, String startKeyDocId, Class<T> classOfT) {
+	private <V,T> Page<T> queryNextPage(int rowsPerPage, String currentStartKey,
+			String currentStartKeyDocId, String startKey, String startKeyDocId, Class<V> classOfV, Class<T> classOfT) {
 		// set view query params
 		limit(rowsPerPage + 1);
 		includeDocs(true);
@@ -308,8 +309,8 @@ public class View {
 		// init page, query view
 		final Page<T> page = new Page<T>();
 		final List<T> pageList = new ArrayList<T>();
-		final ViewResult<String, String, T> vr = queryView(String.class, String.class, classOfT);
-		final List<ViewResult<String, String, T>.Rows> rows = vr.getRows();
+		final ViewResult<String, V, T> vr = queryView(String.class, classOfV, classOfT);
+		final List<ViewResult<String, V, T>.Rows> rows = vr.getRows();
 		final int resultRows = rows.size();
 		final int offset = vr.getOffset();
 		final long totalRows = vr.getTotalRows();
@@ -356,8 +357,8 @@ public class View {
 	/**
 	 * @return The previous page.
 	 */
-	private <T> Page<T> queryPreviousPage(int rowsPerPage, String currentStartKey, 
-			String currentStartKeyDocId, String startKey, String startKeyDocId, Class<T> classOfT) {
+	private <V,T> Page<T> queryPreviousPage(int rowsPerPage, String currentStartKey,
+			String currentStartKeyDocId, String startKey, String startKeyDocId, Class<V> classofV, Class<T> classOfT) {
 		// set view query params
 		limit(rowsPerPage + 1);
 		includeDocs(true);
@@ -367,8 +368,8 @@ public class View {
 		// init page, query view
 		final Page<T> page = new Page<T>();
 		final List<T> pageList = new ArrayList<T>();
-		final ViewResult<String, String, T> vr = queryView(String.class, String.class, classOfT);
-		final List<ViewResult<String, String, T>.Rows> rows = vr.getRows();
+		final ViewResult<String, V, T> vr = queryView(String.class, classofV, classOfT);
+		final List<ViewResult<String, V, T>.Rows> rows = vr.getRows();
 		final int resultRows = rows.size();
 		final int offset = vr.getOffset();
 		final long totalRows = vr.getTotalRows();

--- a/src/test/java/org/lightcouch/tests/ViewsTest.java
+++ b/src/test/java/org/lightcouch/tests/ViewsTest.java
@@ -159,7 +159,7 @@ public class ViewsTest {
 		final int rowsPerPage = 3;
 		// first page - page #1 (rows 1 - 3)
 		Page<Foo> page = dbClient.view("example/foo")
-				.queryPage(rowsPerPage, null, Foo.class);
+				.queryPage(rowsPerPage, null, String.class, Foo.class);
 		assertFalse(page.isHasPrevious());
 		assertTrue(page.isHasNext());
 		assertThat(page.getResultFrom(), is(1));
@@ -169,7 +169,7 @@ public class ViewsTest {
 
 		String param = page.getNextParam();
 		// next page - page #2 (rows 4 - 6)
-		page = dbClient.view("example/foo").queryPage(rowsPerPage, param, Foo.class);
+		page = dbClient.view("example/foo").queryPage(rowsPerPage, param, String.class, Foo.class);
 		assertTrue(page.isHasPrevious());
 		assertTrue(page.isHasNext());
 		assertThat(page.getResultFrom(), is(4));
@@ -179,7 +179,7 @@ public class ViewsTest {
 
 		param = page.getPreviousParam();
 		// previous page, page #1 (rows 1 - 3)
-		page = dbClient.view("example/foo").queryPage(rowsPerPage, param, Foo.class);
+		page = dbClient.view("example/foo").queryPage(rowsPerPage, param, String.class, Foo.class);
 		assertFalse(page.isHasPrevious());
 		assertTrue(page.isHasNext());
 		assertThat(page.getResultFrom(), is(1));
@@ -200,7 +200,7 @@ public class ViewsTest {
 		String pageParam = null;
 		Page<Document> allDocsPage;
 		do {
-			allDocsPage = allDocs.queryPage(2, pageParam, Document.class);
+			allDocsPage = allDocs.queryPage(2, pageParam, Void.class, Document.class);
 			// Do stuff
 			pageParam = allDocsPage.getNextParam();
 		} while (allDocsPage.isHasNext());

--- a/src/test/java/org/lightcouch/tests/ViewsTest.java
+++ b/src/test/java/org/lightcouch/tests/ViewsTest.java
@@ -29,11 +29,7 @@ import java.util.UUID;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.lightcouch.CouchDbClient;
-import org.lightcouch.DocumentConflictException;
-import org.lightcouch.NoDocumentException;
-import org.lightcouch.Page;
-import org.lightcouch.ViewResult;
+import org.lightcouch.*;
 
 import com.google.gson.JsonObject;
 
@@ -163,7 +159,7 @@ public class ViewsTest {
 		final int rowsPerPage = 3;
 		// first page - page #1 (rows 1 - 3)
 		Page<Foo> page = dbClient.view("example/foo")
-				.queryPage(rowsPerPage,	null, Foo.class);
+				.queryPage(rowsPerPage, null, Foo.class);
 		assertFalse(page.isHasPrevious());
 		assertTrue(page.isHasNext());
 		assertThat(page.getResultFrom(), is(1));
@@ -190,6 +186,25 @@ public class ViewsTest {
 		assertThat(page.getResultTo(), is(3));
 		assertThat(page.getPageNumber(), is(1));
 		assertThat(page.getResultList().size(), is(3));
+
+	}
+
+	@Test
+	public void testViewPaginationAllDocs() {
+		for (int i = 0; i < 7; i++) {
+			Foo foo = new Foo(generateUUID(), "all-docs-pagination");
+			dbClient.save(foo);
+		}
+
+		View allDocs = dbClient.view("_all_docs");
+		String pageParam = null;
+		Page<Document> allDocsPage;
+		do {
+			allDocsPage = allDocs.queryPage(2, pageParam, Document.class);
+			// Do stuff
+			pageParam = allDocsPage.getNextParam();
+		} while (allDocsPage.isHasNext());
+
 	}
 
 	private static void init() {

--- a/src/test/java/org/lightcouch/tests/ViewsTest.java
+++ b/src/test/java/org/lightcouch/tests/ViewsTest.java
@@ -196,11 +196,10 @@ public class ViewsTest {
 			dbClient.save(foo);
 		}
 
-		View allDocs = dbClient.view("_all_docs");
 		String pageParam = null;
 		Page<Document> allDocsPage;
 		do {
-			allDocsPage = allDocs.queryPage(2, pageParam, Void.class, Document.class);
+			allDocsPage = dbClient.view("_all_docs").queryPage(2, pageParam, Void.class, Document.class);
 			// Do stuff
 			pageParam = allDocsPage.getNextParam();
 		} while (allDocsPage.isHasNext());


### PR DESCRIPTION
This fixes pagination so that it works in situations where the value in the view isn't a String, an example of this is the _all_docs view.

I also updated the guide, but wasn't sure if you wanted the API to contain backwards compatible methods.

This fixes #50 
