### PR TITLE
Fix url parameter encoding

### DIFF
--- a/src/main/java/org/lightcouch/Params.java
+++ b/src/main/java/org/lightcouch/Params.java
@@ -16,8 +16,9 @@
 
 package org.lightcouch;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,50 +35,44 @@ import java.util.List;
  */
 public class Params {
 
-	private List<String> params = new ArrayList<String>();
+	private List<NameValuePair> params = new ArrayList<NameValuePair>();
 
 	public Params revsInfo() {
-		params.add("revs_info=true");
+		params.add(new BasicNameValuePair("revs_info", "true"));
 		return this;
 	}
 
 	public Params attachments() {
-		params.add("attachments=true");
+		params.add(new BasicNameValuePair("attachments", "true"));
 		return this;
 	}
 
 	public Params revisions() {
-		params.add("revs=true");
+		params.add(new BasicNameValuePair("revs", "true"));
 		return this;
 	}
 
 	public Params rev(String rev) {
-		params.add(String.format("rev=%s", rev));
+		params.add(new BasicNameValuePair("rev", rev));
 		return this;
 	}
 
 	public Params conflicts() {
-		params.add("conflicts=true");
+		params.add(new BasicNameValuePair("conflicts", "true"));
 		return this;
 	}
 
 	public Params localSeq() {
-		params.add("local_seq=true");
+		params.add(new BasicNameValuePair("local_seq", "true"));
 		return this;
 	}
 
 	public Params addParam(String name, String value) {
-		try {
-			name = URLEncoder.encode(name, "UTF-8");
-			value = URLEncoder.encode(value, "UTF-8");
-			params.add(String.format("%s=%s", name, value));
-		} catch (UnsupportedEncodingException e) {
-			throw new IllegalArgumentException(e);
-		}
+		params.add(new BasicNameValuePair(name, value));
 		return this;
 	}
 
-	public List<String> getParams() {
+	public List<NameValuePair> getParams() {
 		return params.isEmpty() ? null : params;
 	}
 }

--- a/src/main/java/org/lightcouch/View.java
+++ b/src/main/java/org/lightcouch/View.java
@@ -540,7 +540,7 @@ public class View {
 	 * @param keys
 	 * @return
 	 */
-	public View keys(List<String> keys) {
+	public View keys(List<?> keys) {
 		this.allDocsKeys = String.format("{%s:%s}", gson.toJson("keys"), gson.toJson(keys));
 		return this;
 	}

--- a/src/test/java/org/lightcouch/tests/UpdateHandlerTest.java
+++ b/src/test/java/org/lightcouch/tests/UpdateHandlerTest.java
@@ -56,7 +56,7 @@ public class UpdateHandlerTest {
 		Foo foo = dbClient.find(Foo.class, response.getId());
 		
 		assertNotNull(output);
-		assertEquals(foo.getTitle(), newValue);
+		assertEquals(newValue, foo.getTitle());
 	}
 	
 	@Test
@@ -75,6 +75,6 @@ public class UpdateHandlerTest {
 		Foo foo = dbClient.find(Foo.class, response.getId());
 		
 		assertNotNull(output);
-		assertEquals(foo.getTitle(), newValue);
+		assertEquals(newValue, foo.getTitle());
 	}
 }

--- a/src/test/java/org/lightcouch/tests/ViewsTest.java
+++ b/src/test/java/org/lightcouch/tests/ViewsTest.java
@@ -45,7 +45,6 @@ public class ViewsTest {
 	@BeforeClass
 	public static void setUpClass() {
 		dbClient = new CouchDbClient();
-
 		dbClient.syncDesignDocsWithDb();
 		
 		init(); 
@@ -69,6 +68,15 @@ public class ViewsTest {
 		List<Foo> foos = dbClient.view("example/foo")
 				.includeDocs(true)
 				.key("key-1")
+				.query(Foo.class);
+		assertThat(foos.size(), is(1));
+	}
+
+	@Test
+	public void byKeyWithPlus() {
+		List<Foo> foos = dbClient.view("example/foo")
+				.includeDocs(true)
+				.key("+key-4")
 				.query(Foo.class);
 		assertThat(foos.size(), is(1));
 	}
@@ -112,7 +120,7 @@ public class ViewsTest {
 		ViewResult<int[], String, Foo> viewResult = dbClient.view("example/by_date")
 				.reduce(false)
 				.queryView(int[].class, String.class, Foo.class);
-		assertThat(viewResult.getRows().size(), is(3));
+		assertThat(viewResult.getRows().size(), is(4));
 	}
 
 	@Test
@@ -210,19 +218,22 @@ public class ViewsTest {
 			Foo foo = null;
 
 			foo = new Foo("id-1", "key-1");
-			foo.setTags(Arrays.asList(new String[] { "couchdb", "views" }));
-			foo.setComplexDate(new int[] { 2011, 10, 15 });
+			foo.setTags(Arrays.asList(new String[]{"couchdb", "views"}));
+			foo.setComplexDate(new int[]{2011, 10, 15});
 			dbClient.save(foo);
 
 			foo = new Foo("id-2", "key-2");
-			foo.setTags(Arrays.asList(new String[] { "java", "couchdb" }));
-			foo.setComplexDate(new int[] { 2011, 10, 15 });
+			foo.setTags(Arrays.asList(new String[]{"java", "couchdb"}));
+			foo.setComplexDate(new int[]{2011, 10, 15});
 			dbClient.save(foo);
 
 			foo = new Foo("id-3", "key-3");
-			foo.setComplexDate(new int[] { 2013, 12, 17 });
+			foo.setComplexDate(new int[]{2013, 12, 17});
 			dbClient.save(foo);
 
+			foo = new Foo("id-4", "+key-4");
+			foo.setComplexDate(new int[]{2013, 12, 17});
+			dbClient.save(foo);
 		} catch (DocumentConflictException e) {
 		}
 	}

--- a/src/test/java/org/lightcouch/tests/ViewsTest.java
+++ b/src/test/java/org/lightcouch/tests/ViewsTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.Vector;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -92,6 +93,18 @@ public class ViewsTest {
 				.reduce(false)
 				.query(Foo.class);
 		assertThat(foos.size(), is(2));
+	}
+
+	@Test
+	public void byComplexKeys() {
+		List<int[]> keysToGet = new Vector<int[]>();
+		keysToGet.add(new int[] { 2011, 10, 15 });
+		keysToGet.add(new int[] { 2013, 12, 17 });
+		ViewResult<Integer[], Integer, Foo> fooRows = dbClient.view("example/by_date")
+				.keys(keysToGet)
+				.group(true)
+				.queryView(Integer[].class, Integer.class, Foo.class);
+		assertThat(fooRows.getRows().size(), is(2));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes issue #52

Please note that this fix has one behavior change that I believe should not affect anyone:
Previously you could mix usages of `org.lightcouch.URIBuilder#query(String name, Object value)` and `org.lightcouch.URIBuilder#query(String query)` (although I highly doubt that ever worked because it seems there was no proper handling of when to add the ampersand "&" character between the inputs of the two methods).
After this commit the behavior is that the latter form (`org.lightcouch.URIBuilder#query(String query)`) takes precedence.