### PR TITLE
Initial docker/travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+
+language: java
+
+services:
+  - docker
+
+before_install:
+  - docker pull frodenas/couchdb:1.6
+  - docker run -d -p 127.0.0.1:5984:5984 -e COUCHDB_USERNAME=couchdb -e COUCHDB_PASSWORD=couchdb frodenas/couchdb:1.6
+  - sed 's/^couchdb.username.*/couchdb.username=couchdb/;s/^couchdb.password.*/couchdb.password=couchdb/' -i src/test/resources/couchdb.properties


### PR DESCRIPTION
This allows this project to build and test on travis-ci.org
It uses docker to bring up a copy of couchdb for running the tests against.