### PR TITLE
Added checking the "stop" flag between subsequent "readLine" calls. 

### DIFF
--- a/src/main/java/org/lightcouch/Changes.java
+++ b/src/main/java/org/lightcouch/Changes.java
@@ -90,7 +90,7 @@ public class Changes {
 		setReader(new BufferedReader(is));
 		return this;
 	}
-
+	
 	/**
 	 * Checks whether a feed is available in the continuous stream, blocking 
 	 * until a feed is received. 
@@ -166,16 +166,16 @@ public class Changes {
 	private boolean readNextRow() {
 		boolean hasNext = false;
 		try {
-			if(!stop) {
-				String row = ""; 
-				do {
-					row = getReader().readLine(); 
-				} while(row.length() == 0);
-				
-				if(!row.startsWith("{\"last_seq\":")) { 
-					setNextRow(gson.fromJson(row, Row.class));
-					hasNext = true;
-				} 
+			String row = ""; 
+			while(!stop && row.length() == 0) {
+				row = getReader().readLine(); 
+				if (Thread.interrupted()) {
+					stop();
+				}
+			} 
+			if(!stop && !row.startsWith("{\"last_seq\":")) { 
+				setNextRow(gson.fromJson(row, Row.class));
+				hasNext = true;
 			} 
 		} catch (Exception e) {
 			terminate();


### PR DESCRIPTION
The problem I am trying to address, is waiting  forever for the "readNextRow" method to return. when there is no change in the database.  

I have added checking the "stop" flag between subsequent "readLine" calls. I have also added checking "Thread.interrupted" in order to allow for graceful termination when the thread is interrupted.

As the "readLine" method is blocking and takes quite long time to return, it may be also valuable to close underlying stream in "stop" method, which enables another thread to call it, in order to make it  returning immediately.
