### PR TITLE
Fix sync design docs with DB for spring boot

### DIFF
--- a/src/main/java/org/lightcouch/CouchDbUtil.java
+++ b/src/main/java/org/lightcouch/CouchDbUtil.java
@@ -46,7 +46,9 @@ import com.google.gson.JsonObject;
  */
 final class CouchDbUtil {
 
-	private CouchDbUtil() {
+  public static final String SPRING_BOOT_DIR = "BOOT-INF/classes/";
+
+  private CouchDbUtil() {
 		// Utility class
 	}
 	
@@ -105,7 +107,6 @@ final class CouchDbUtil {
 	 * Works for regular files and also JARs.
 	 * 
 	 * @author Greg Briggs
-	 * @param clazz Any java class that lives in the same place as the resources you want.
 	 * @param path Should end with "/", but not start with one.
 	 * @return Just the name of each member item, not the full paths.
 	 */
@@ -123,6 +124,9 @@ final class CouchDbUtil {
 				Set<String> result = new HashSet<String>(); 
 				while(entries.hasMoreElements()) {
 					String name = entries.nextElement().getName();
+          if (name.startsWith(SPRING_BOOT_DIR)) {
+            name = name.substring(SPRING_BOOT_DIR.length());
+          }
 					if (name.startsWith(path)) { 
 						String entry = name.substring(path.length());
 						int checkSubdir = entry.indexOf("/");
@@ -142,7 +146,7 @@ final class CouchDbUtil {
 			throw new CouchDbException(e);
 		}
 	}
-	
+
 	public static String readFile(String path) {
 		InputStream instream = CouchDbUtil.class.getResourceAsStream(path);
 		StringBuilder content = new StringBuilder();


### PR DESCRIPTION
Spring boot version 1.4.2 creates a JAR file where classes, libs and resources are included in BOOT-INF directory. I did a fix for loading design-docs folder when CouchDB view documents are grouped into the maven resources. Further improvements can be done later for /static and /public spring boot folders if is necessary. 